### PR TITLE
시장 장보기 의뢰글 등록 구현

### DIFF
--- a/src/main/java/com/example/demo/exception/type/ErrorCode.java
+++ b/src/main/java/com/example/demo/exception/type/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 채팅방입니다."),
     COMMUNITY_NOT_FOUND(HttpStatus.NOT_FOUND.value(),"커뮤니티를 찾을 수 없습니다."),
     REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 의뢰글 입니다,"),
+    MARKET_NOT_FOUND(HttpStatus.NOT_FOUND.value(),"시장을 찾을 수 없습니다."),
 
     // UNAUTHORIZED
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED.value(), "로그인이 필요한 서비스입니다."),

--- a/src/main/java/com/example/demo/market/entity/Market.java
+++ b/src/main/java/com/example/demo/market/entity/Market.java
@@ -12,7 +12,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/example/demo/marketpurchaserequest/controller/api/MarketPurchaseRequestApiController.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/controller/api/MarketPurchaseRequestApiController.java
@@ -2,7 +2,6 @@ package com.example.demo.marketpurchaserequest.controller.api;
 
 import com.example.demo.marketpurchaserequest.dto.MarketPurchaseRequestDto;
 import com.example.demo.marketpurchaserequest.service.MarketPurchaseRequestService;
-import com.example.demo.marketpurchaserequest.service.impl.MarketPurchaseRequestServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class MarketPurchaseRequestApiController {
 
-    private final MarketPurchaseRequestServiceImpl marketPurchaseRequestServiceImpl;
+    private final MarketPurchaseRequestService marketPurchaseRequestService;
 
     @PostMapping("/requests")
     public ResponseEntity<String> createMarketPurchaseRequest(@RequestBody MarketPurchaseRequestDto request) {
-        marketPurchaseRequestServiceImpl.createMarketPurchaseRequest(request.toEntity(), request.getUserId(), request.getMarketId());
+        marketPurchaseRequestService.createMarketPurchaseRequest(request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/demo/marketpurchaserequest/controller/api/MarketPurchaseRequestApiController.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/controller/api/MarketPurchaseRequestApiController.java
@@ -1,0 +1,27 @@
+package com.example.demo.marketpurchaserequest.controller.api;
+
+import com.example.demo.marketpurchaserequest.dto.MarketPurchaseRequestDto;
+import com.example.demo.marketpurchaserequest.service.MarketPurchaseRequestService;
+import com.example.demo.marketpurchaserequest.service.impl.MarketPurchaseRequestServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MarketPurchaseRequestApiController {
+
+    private final MarketPurchaseRequestServiceImpl marketPurchaseRequestServiceImpl;
+
+    @PostMapping("/requests")
+    public ResponseEntity<String> createMarketPurchaseRequest(@RequestBody MarketPurchaseRequestDto request) {
+        marketPurchaseRequestServiceImpl.createMarketPurchaseRequest(request.toEntity(), request.getUserId(), request.getMarketId());
+        return ResponseEntity.ok().build();
+    }
+
+
+}

--- a/src/main/java/com/example/demo/marketpurchaserequest/dto/MarketPurchaseRequestDto.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/dto/MarketPurchaseRequestDto.java
@@ -3,14 +3,12 @@ package com.example.demo.marketpurchaserequest.dto;
 import com.example.demo.market.entity.Market;
 import com.example.demo.marketpurchaserequest.entity.MarketPurchaseRequest;
 import com.example.demo.siteuser.entity.SiteUser;
-import com.example.demo.type.PurchaseRequestStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
@@ -19,27 +17,24 @@ import org.locationtech.jts.geom.PrecisionModel;
 @Getter
 public class MarketPurchaseRequestDto {
 
-    @NotBlank
+    @NotBlank(message = "제목을 입력하세요.")
     private String title;
 
-    @NotBlank
+    @NotBlank(message = "내용을 입력하세요.")
     private String content;
 
     private String postImg;
 
-    @NotEmpty
+    @NotEmpty(message = "수수료를 입력하세요.")
     private int fee;
 
-    @NotEmpty
-    private PurchaseRequestStatus status;
-
-    @NotEmpty
+    @NotEmpty(message = "약속 시간을 입력하세요.")
     private LocalDate meetupTime;
 
-    @NotEmpty
+    @NotEmpty(message = "약속 날짜 입력하세요.")
     private LocalDate meetupDate;
 
-    @NotBlank
+    @NotBlank(message = "약속 주소를 입력하세요.")
     private String meetupAddress;
 
     private Double latitude;
@@ -50,13 +45,12 @@ public class MarketPurchaseRequestDto {
     private Long marketId;
 
     @Builder
-    public MarketPurchaseRequestDto(String title, String content, String postImg, int fee, PurchaseRequestStatus status,
+    public MarketPurchaseRequestDto(String title, String content, String postImg, int fee,
             LocalDate meetupTime, LocalDate meetupDate, String meetupAddress, double latitude, double longitude, Long userId, Long marketId) {
         this.title = title;
         this.content = content;
         this.postImg = postImg;
         this.fee = fee;
-        this.status = status;
         this.meetupTime = meetupTime;
         this.meetupDate = meetupDate;
         this.meetupAddress = meetupAddress;

--- a/src/main/java/com/example/demo/marketpurchaserequest/dto/MarketPurchaseRequestDto.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/dto/MarketPurchaseRequestDto.java
@@ -17,7 +17,6 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 
 @Getter
-@Setter
 public class MarketPurchaseRequestDto {
 
     @NotBlank

--- a/src/main/java/com/example/demo/marketpurchaserequest/dto/MarketPurchaseRequestDto.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/dto/MarketPurchaseRequestDto.java
@@ -20,27 +20,27 @@ import org.locationtech.jts.geom.PrecisionModel;
 @Setter
 public class MarketPurchaseRequestDto {
 
-    @NotBlank(message = "[required] 제목을 입력하세요.")
+    @NotBlank
     private String title;
 
-    @NotBlank(message = "[required] 내용을 입력하세요.")
+    @NotBlank
     private String content;
 
     private String postImg;
 
-    @NotEmpty(message = "[required] 수수료를 입력하세요.")
+    @NotEmpty
     private int fee;
 
-    @NotEmpty(message = "[required] 의뢰글 상태 입력하세요.")
+    @NotEmpty
     private PurchaseRequestStatus status;
 
-    @NotEmpty(message = "[required] 만나는 시간을 입력하세요.")
+    @NotEmpty
     private LocalDate meetupTime;
 
-    @NotEmpty(message = "[required] 만나는 날짜 입력하세요.")
+    @NotEmpty
     private LocalDate meetupDate;
 
-    @NotBlank(message = "[required] 만날 주소를 입력하세요.")
+    @NotBlank
     private String meetupAddress;
 
     private Double latitude;

--- a/src/main/java/com/example/demo/marketpurchaserequest/dto/MarketPurchaseRequestDto.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/dto/MarketPurchaseRequestDto.java
@@ -1,0 +1,89 @@
+package com.example.demo.marketpurchaserequest.dto;
+
+import com.example.demo.marketpurchaserequest.entity.MarketPurchaseRequest;
+import com.example.demo.type.PurchaseRequestStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+
+@Getter
+@Setter
+public class MarketPurchaseRequestDto {
+
+    @NotBlank(message = "[required] 제목을 입력하세요.")
+    private String title;
+
+    @NotBlank(message = "[required] 내용을 입력하세요.")
+    private String content;
+
+    private String postImg;
+
+    @NotEmpty(message = "[required] 수수료를 입력하세요.")
+    private int fee;
+
+    @NotEmpty(message = "[required] 의뢰글 상태 입력하세요.")
+    private PurchaseRequestStatus status;
+
+    @NotEmpty(message = "[required] 만나는 시간을 입력하세요.")
+    private LocalDate meetupTime;
+
+    @NotEmpty(message = "[required] 만나는 날짜 입력하세요.")
+    private LocalDate meetupDate;
+
+    @NotBlank(message = "[required] 만날 주소를 입력하세요.")
+    private String meetupAddress;
+
+    private Double latitude;
+    private Double longitude;
+
+    private Long userId;
+
+    private Long marketId;
+
+    @Builder
+    public MarketPurchaseRequestDto(String title, String content, String postImg, int fee, PurchaseRequestStatus status,
+            LocalDate meetupTime, LocalDate meetupDate, String meetupAddress, double latitude, double longitude, Long userId, Long marketId) {
+        this.title = title;
+        this.content = content;
+        this.postImg = postImg;
+        this.fee = fee;
+        this.status = status;
+        this.meetupTime = meetupTime;
+        this.meetupDate = meetupDate;
+        this.meetupAddress = meetupAddress;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.userId = userId;
+        this.marketId = marketId;
+
+
+    }
+    public Point getPoint(double latitude, double longitude) {
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        return geometryFactory.createPoint(new Coordinate(latitude, longitude));
+    }
+
+    public MarketPurchaseRequest toEntity() {
+        return MarketPurchaseRequest.builder()
+                .title(title)
+                .content(content)
+                .postImg(postImg)
+                .fee(fee)
+                .meetupTime(meetupTime)
+                .meetupDate(meetupDate)
+                .meetupAddress(meetupAddress)
+                .meetupLocation(getPoint(longitude, longitude))
+                .createdAt(LocalDateTime.now())
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/example/demo/marketpurchaserequest/dto/MarketPurchaseRequestDto.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/dto/MarketPurchaseRequestDto.java
@@ -1,6 +1,8 @@
 package com.example.demo.marketpurchaserequest.dto;
 
+import com.example.demo.market.entity.Market;
 import com.example.demo.marketpurchaserequest.entity.MarketPurchaseRequest;
+import com.example.demo.siteuser.entity.SiteUser;
 import com.example.demo.type.PurchaseRequestStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -71,7 +73,7 @@ public class MarketPurchaseRequestDto {
         return geometryFactory.createPoint(new Coordinate(latitude, longitude));
     }
 
-    public MarketPurchaseRequest toEntity() {
+    public MarketPurchaseRequest toEntity(SiteUser siteUser, Market market) {
         return MarketPurchaseRequest.builder()
                 .title(title)
                 .content(content)
@@ -82,6 +84,8 @@ public class MarketPurchaseRequestDto {
                 .meetupAddress(meetupAddress)
                 .meetupLocation(getPoint(longitude, longitude))
                 .createdAt(LocalDateTime.now())
+                .siteUser(siteUser)
+                .market(market)
                 .build();
 
     }

--- a/src/main/java/com/example/demo/marketpurchaserequest/entity/MarketPurchaseRequest.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/entity/MarketPurchaseRequest.java
@@ -102,4 +102,13 @@ public class MarketPurchaseRequest {
     @LastModifiedDate
     @Column(name = "UPDATED_AT")
     private LocalDateTime updatedAt;
+
+    public void setUser(SiteUser siteUser) {
+        this.siteUser = siteUser;
+        siteUser.getPurchaseRequests().add(this);
+    }
+    public void setMarket(Market market) {
+        this.market = market;
+        market.getMarketPurchaseRequests().add(this);
+    }
 }

--- a/src/main/java/com/example/demo/marketpurchaserequest/entity/MarketPurchaseRequest.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/entity/MarketPurchaseRequest.java
@@ -103,12 +103,12 @@ public class MarketPurchaseRequest {
     @Column(name = "UPDATED_AT")
     private LocalDateTime updatedAt;
 
-    public void setUser(SiteUser siteUser) {
-        this.siteUser = siteUser;
-        siteUser.getPurchaseRequests().add(this);
-    }
-    public void setMarket(Market market) {
-        this.market = market;
-        market.getMarketPurchaseRequests().add(this);
-    }
+//    public void setUser(SiteUser siteUser) {
+//        this.siteUser = siteUser;
+//        siteUser.getPurchaseRequests().add(this);
+//    }
+//    public void setMarket(Market market) {
+//        this.market = market;
+//        market.getMarketPurchaseRequests().add(this);
+//    }
 }

--- a/src/main/java/com/example/demo/marketpurchaserequest/entity/MarketPurchaseRequest.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/entity/MarketPurchaseRequest.java
@@ -103,12 +103,4 @@ public class MarketPurchaseRequest {
     @Column(name = "UPDATED_AT")
     private LocalDateTime updatedAt;
 
-//    public void setUser(SiteUser siteUser) {
-//        this.siteUser = siteUser;
-//        siteUser.getPurchaseRequests().add(this);
-//    }
-//    public void setMarket(Market market) {
-//        this.market = market;
-//        market.getMarketPurchaseRequests().add(this);
-//    }
 }

--- a/src/main/java/com/example/demo/marketpurchaserequest/repository/MarketPurchaseRequestRepository.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/repository/MarketPurchaseRequestRepository.java
@@ -2,7 +2,9 @@ package com.example.demo.marketpurchaserequest.repository;
 
 import com.example.demo.marketpurchaserequest.entity.MarketPurchaseRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MarketPurchaseRequestRepository extends JpaRepository<MarketPurchaseRequest,Long> {
 
 }

--- a/src/main/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestService.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestService.java
@@ -1,0 +1,9 @@
+package com.example.demo.marketpurchaserequest.service;
+
+import com.example.demo.marketpurchaserequest.entity.MarketPurchaseRequest;
+
+public interface MarketPurchaseRequestService {
+
+    MarketPurchaseRequest createMarketPurchaseRequest(MarketPurchaseRequest marketPurchaseRequest, Long siteUserId, Long marketId);
+
+}

--- a/src/main/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestService.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestService.java
@@ -1,9 +1,10 @@
 package com.example.demo.marketpurchaserequest.service;
 
+import com.example.demo.marketpurchaserequest.dto.MarketPurchaseRequestDto;
 import com.example.demo.marketpurchaserequest.entity.MarketPurchaseRequest;
 
 public interface MarketPurchaseRequestService {
 
-    MarketPurchaseRequest createMarketPurchaseRequest(MarketPurchaseRequest marketPurchaseRequest, Long siteUserId, Long marketId);
-
+    MarketPurchaseRequest createMarketPurchaseRequest(
+            MarketPurchaseRequestDto marketPurchaseRequestDto);
 }

--- a/src/main/java/com/example/demo/marketpurchaserequest/service/impl/MarketPurchaseRequestServiceImpl.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/service/impl/MarketPurchaseRequestServiceImpl.java
@@ -30,18 +30,4 @@ public class MarketPurchaseRequestServiceImpl implements MarketPurchaseRequestSe
         Market market = marketRepository.findById(marketPurchaseRequestDto.getMarketId()).orElseThrow(()-> new MarkethingException(ErrorCode.MARKET_NOT_FOUND));
         return marketPurchaseRequestRepository.save(marketPurchaseRequestDto.toEntity(siteUser,market));
     }
-
-
-//    @Override
-//    @Transactional
-//    public MarketPurchaseRequest createMarketPurchaseRequest(
-//            MarketPurchaseRequest marketPurchaseRequest) {
-//        SiteUser siteUser = siteUserRepository.findById(siteUserId).orElseThrow(() -> new MarkethingException(
-//                ErrorCode.USER_NOT_FOUND));
-//        Market market = marketRepository.findById(marketId).orElseThrow(()->new MarkethingException(ErrorCode.MARKET_NOT_FOUND));
-////        marketPurchaseRequest.setUser(siteUser);
-////        marketPurchaseRequest.setMarket(market);
-//        return marketPurchaseRequestRepository.save(marketPurchaseRequest);
-//
-//    }
 }

--- a/src/main/java/com/example/demo/marketpurchaserequest/service/impl/MarketPurchaseRequestServiceImpl.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/service/impl/MarketPurchaseRequestServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.demo.exception.MarkethingException;
 import com.example.demo.exception.type.ErrorCode;
 import com.example.demo.market.entity.Market;
 import com.example.demo.market.repository.MarketRepository;
+import com.example.demo.marketpurchaserequest.dto.MarketPurchaseRequestDto;
 import com.example.demo.marketpurchaserequest.entity.MarketPurchaseRequest;
 import com.example.demo.marketpurchaserequest.repository.MarketPurchaseRequestRepository;
 import com.example.demo.marketpurchaserequest.service.MarketPurchaseRequestService;
@@ -24,13 +25,23 @@ public class MarketPurchaseRequestServiceImpl implements MarketPurchaseRequestSe
     @Override
     @Transactional
     public MarketPurchaseRequest createMarketPurchaseRequest(
-            MarketPurchaseRequest marketPurchaseRequest, Long siteUserId, Long marketId) {
-        SiteUser siteUser = siteUserRepository.findById(siteUserId).orElseThrow(() -> new MarkethingException(
-                ErrorCode.USER_NOT_FOUND));
-        Market market = marketRepository.findById(marketId).orElseThrow(()->new MarkethingException(ErrorCode.MARKET_NOT_FOUND));
-        marketPurchaseRequest.setMarket(market);
-        marketPurchaseRequest.setUser(siteUser);
-        return marketPurchaseRequestRepository.save(marketPurchaseRequest);
-
+            MarketPurchaseRequestDto marketPurchaseRequestDto) {
+        SiteUser siteUser = siteUserRepository.findById(marketPurchaseRequestDto.getUserId()).orElseThrow(() -> new MarkethingException(ErrorCode.USER_NOT_FOUND));
+        Market market = marketRepository.findById(marketPurchaseRequestDto.getMarketId()).orElseThrow(()-> new MarkethingException(ErrorCode.MARKET_NOT_FOUND));
+        return marketPurchaseRequestRepository.save(marketPurchaseRequestDto.toEntity(siteUser,market));
     }
+
+
+//    @Override
+//    @Transactional
+//    public MarketPurchaseRequest createMarketPurchaseRequest(
+//            MarketPurchaseRequest marketPurchaseRequest) {
+//        SiteUser siteUser = siteUserRepository.findById(siteUserId).orElseThrow(() -> new MarkethingException(
+//                ErrorCode.USER_NOT_FOUND));
+//        Market market = marketRepository.findById(marketId).orElseThrow(()->new MarkethingException(ErrorCode.MARKET_NOT_FOUND));
+////        marketPurchaseRequest.setUser(siteUser);
+////        marketPurchaseRequest.setMarket(market);
+//        return marketPurchaseRequestRepository.save(marketPurchaseRequest);
+//
+//    }
 }

--- a/src/main/java/com/example/demo/marketpurchaserequest/service/impl/MarketPurchaseRequestServiceImpl.java
+++ b/src/main/java/com/example/demo/marketpurchaserequest/service/impl/MarketPurchaseRequestServiceImpl.java
@@ -1,0 +1,36 @@
+package com.example.demo.marketpurchaserequest.service.impl;
+
+import com.example.demo.exception.MarkethingException;
+import com.example.demo.exception.type.ErrorCode;
+import com.example.demo.market.entity.Market;
+import com.example.demo.market.repository.MarketRepository;
+import com.example.demo.marketpurchaserequest.entity.MarketPurchaseRequest;
+import com.example.demo.marketpurchaserequest.repository.MarketPurchaseRequestRepository;
+import com.example.demo.marketpurchaserequest.service.MarketPurchaseRequestService;
+import com.example.demo.siteuser.entity.SiteUser;
+import com.example.demo.siteuser.repository.SiteUserRepository;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MarketPurchaseRequestServiceImpl implements MarketPurchaseRequestService {
+
+    private final MarketPurchaseRequestRepository marketPurchaseRequestRepository;
+    private final SiteUserRepository siteUserRepository;
+    private final MarketRepository marketRepository;
+
+    @Override
+    @Transactional
+    public MarketPurchaseRequest createMarketPurchaseRequest(
+            MarketPurchaseRequest marketPurchaseRequest, Long siteUserId, Long marketId) {
+        SiteUser siteUser = siteUserRepository.findById(siteUserId).orElseThrow(() -> new MarkethingException(
+                ErrorCode.USER_NOT_FOUND));
+        Market market = marketRepository.findById(marketId).orElseThrow(()->new MarkethingException(ErrorCode.MARKET_NOT_FOUND));
+        marketPurchaseRequest.setMarket(market);
+        marketPurchaseRequest.setUser(siteUser);
+        return marketPurchaseRequestRepository.save(marketPurchaseRequest);
+
+    }
+}

--- a/src/main/java/com/example/demo/siteuser/entity/SiteUser.java
+++ b/src/main/java/com/example/demo/siteuser/entity/SiteUser.java
@@ -1,6 +1,5 @@
 package com.example.demo.siteuser.entity;
 
-import com.example.demo.chat.entiity.ChatMessage;
 import com.example.demo.community.entity.Community;
 import com.example.demo.entity.Account;
 import com.example.demo.chat.entiity.ChatRoom;
@@ -111,7 +110,6 @@ public class SiteUser {
 
     @OneToMany(mappedBy = "siteUser", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MarketPurchaseRequest> purchaseRequests;
-
 
     @OneToMany(mappedBy = "siteUser", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RequestSuccess> requestSuccesses;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -279,11 +279,11 @@ ALTER TABLE
         FOREIGN KEY (`PAYMENT_ID`) REFERENCES `PAYMENT` (`ID`)
             ON DELETE CASCADE;
 
-ALTER TABLE
-    `CHAT_MESSAGE`
-    ADD CONSTRAINT `chat_message_room_id_foreign`
-        FOREIGN KEY (`ROOM_ID`) REFERENCES `CHATROOM` (`ID`)
-            ON DELETE CASCADE;
+-- ALTER TABLE
+--     `CHAT_MESSAGE`
+--     ADD CONSTRAINT `chat_message_room_id_foreign`
+--         FOREIGN KEY (`ROOM_ID`) REFERENCES `CHATROOM` (`ID`)
+--             ON DELETE CASCADE;
 
 ALTER TABLE
     `COMMENT`

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -279,12 +279,6 @@ ALTER TABLE
         FOREIGN KEY (`PAYMENT_ID`) REFERENCES `PAYMENT` (`ID`)
             ON DELETE CASCADE;
 
--- ALTER TABLE
---     `CHAT_MESSAGE`
---     ADD CONSTRAINT `chat_message_room_id_foreign`
---         FOREIGN KEY (`ROOM_ID`) REFERENCES `CHATROOM` (`ID`)
---             ON DELETE CASCADE;
-
 ALTER TABLE
     `COMMENT`
     ADD CONSTRAINT `comment_post_id_foreign`

--- a/src/test/java/com/example/demo/marketpurchaserequest/controller/MarketPurchaseRequestApiControllerTest.java
+++ b/src/test/java/com/example/demo/marketpurchaserequest/controller/MarketPurchaseRequestApiControllerTest.java
@@ -1,0 +1,102 @@
+package com.example.demo.marketpurchaserequest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.demo.market.entity.Market;
+import com.example.demo.marketpurchaserequest.controller.api.MarketPurchaseRequestApiController;
+import com.example.demo.marketpurchaserequest.dto.MarketPurchaseRequestDto;
+import com.example.demo.marketpurchaserequest.entity.MarketPurchaseRequest;
+import com.example.demo.marketpurchaserequest.service.MarketPurchaseRequestService;
+import com.example.demo.siteuser.entity.SiteUser;
+import com.example.demo.type.AuthType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(controllers = MarketPurchaseRequestApiController.class)
+public class MarketPurchaseRequestApiControllerTest {
+
+    @MockBean
+    private MarketPurchaseRequestService marketPurchaseRequestService;
+
+    @MockBean
+    private MappingMongoConverter mappingMongoConverter;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+
+    private final SiteUser siteUser = SiteUser.builder()
+            .id(1L)
+            .email("mockEmail@gmail.com")
+            .password("password")
+            .name("name")
+            .nickname("nickname")
+            .phoneNumber("010-1234-5678")
+            .address("address")
+            .myLocation(geometryFactory.createPoint(new Coordinate(37.56600357774501, 126.97306266269747)))
+            .mannerScore(0)
+            .profileImg("profileImg")
+            .status(true)
+            .authType(AuthType.GENERAL)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+    private final Market market = Market.builder()
+            .id(1L)
+            .idNum(04003)
+            .marketName("강릉중앙시장")
+            .type(1)
+            .roadAddress("강원특별자치도 강릉시 금성로21")
+            .streetAddress("강원특별자치도 강릉시 성남동 50")
+            .location(geometryFactory.createPoint(new Coordinate(37.75402359, 128.8986233)))
+            .build();
+
+    @Test
+    void createMarketPurchaseRequest() throws Exception {
+        // given
+        MarketPurchaseRequestDto marketPurchaseRequestDto = MarketPurchaseRequestDto.builder()
+                .title("test request")
+                .content("3 apples")
+                .fee(15000)
+                .meetupTime(LocalDate.now())
+                .meetupDate(LocalDate.now())
+                .meetupAddress("서울시")
+                .latitude(37.5509)
+                .longitude(127.0506)
+                .userId(siteUser.getId())
+                .marketId(market.getId())
+                .build();
+
+        MarketPurchaseRequest marketPurchaseRequest = marketPurchaseRequestDto.toEntity(siteUser,market);
+
+        given(marketPurchaseRequestService.createMarketPurchaseRequest(any())).willReturn(marketPurchaseRequest);
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
+                .post("/api/requests")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(marketPurchaseRequestDto)));
+        // then
+        resultActions.andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestServiceImplTest.java
+++ b/src/test/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestServiceImplTest.java
@@ -1,0 +1,113 @@
+package com.example.demo.marketpurchaserequest.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.example.demo.market.entity.Market;
+import com.example.demo.market.repository.MarketRepository;
+import com.example.demo.marketpurchaserequest.dto.MarketPurchaseRequestDto;
+import com.example.demo.marketpurchaserequest.entity.MarketPurchaseRequest;
+import com.example.demo.marketpurchaserequest.repository.MarketPurchaseRequestRepository;
+import com.example.demo.marketpurchaserequest.service.impl.MarketPurchaseRequestServiceImpl;
+import com.example.demo.siteuser.entity.SiteUser;
+import com.example.demo.siteuser.repository.SiteUserRepository;
+import com.example.demo.type.AuthType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MarketPurchaseRequestServiceImplTest {
+
+    @InjectMocks
+    private MarketPurchaseRequestServiceImpl marketPurchaseRequestServiceImpl;
+
+    @Mock
+    private MarketPurchaseRequestRepository marketPurchaseRequestRepository;
+
+    @Mock
+    private SiteUserRepository siteUserRepository;
+
+    @Mock
+    private MarketRepository marketRepository;
+
+    private static final GeometryFactory geometryFactory = new GeometryFactory();
+
+    @Test
+    void createMarketPurchaseRequest() {
+        //given
+        Market market = getMarket();
+        SiteUser siteUser = getSiteUser();
+        MarketPurchaseRequestDto marketPurchaseRequestDto = getMarketPurchaseRequestDto(siteUser,market);
+        MarketPurchaseRequest marketPurchaseRequest = marketPurchaseRequestDto.toEntity(siteUser, market);
+
+        //mocking
+        given(siteUserRepository.findById(any())).willReturn(Optional.ofNullable(siteUser));
+        given(marketRepository.findById(any())).willReturn(Optional.ofNullable(market));
+        given(marketPurchaseRequestRepository.save(any(MarketPurchaseRequest.class))).willReturn(marketPurchaseRequest);
+        given(marketPurchaseRequestRepository.findById(marketPurchaseRequest.getId())).willReturn(Optional.ofNullable(marketPurchaseRequest));
+
+        // when
+        MarketPurchaseRequest newMarketPurchaseRequest = marketPurchaseRequestServiceImpl.createMarketPurchaseRequest(marketPurchaseRequestDto);
+
+        // then
+        MarketPurchaseRequest findMarketPurchaseRequest = marketPurchaseRequestRepository.findById(newMarketPurchaseRequest.getId()).orElse(null);
+
+        assertEquals(marketPurchaseRequest.getId(),findMarketPurchaseRequest.getId());
+
+    }
+
+    private static MarketPurchaseRequestDto getMarketPurchaseRequestDto(SiteUser siteUser, Market market) {
+        return MarketPurchaseRequestDto.builder()
+                .title("test request")
+                .content("3 apples")
+                .fee(15000)
+                .meetupTime(LocalDate.now())
+                .meetupDate(LocalDate.now())
+                .meetupAddress("서울시")
+                .latitude(37.5509)
+                .longitude(127.0506)
+                .userId(siteUser.getId())
+                .marketId(market.getId())
+                .build();
+    }
+
+    private static SiteUser getSiteUser() {
+        return SiteUser.builder()
+                .id(1L)
+                .email("mockEmail@gmail.com")
+                .password("password")
+                .name("name")
+                .nickname("nickname")
+                .phoneNumber("010-1234-5678")
+                .address("address")
+                .myLocation(geometryFactory.createPoint(new Coordinate(37.56600357774501, 126.97306266269747)))
+                .mannerScore(0)
+                .profileImg("profileImg")
+                .status(true)
+                .authType(AuthType.GENERAL)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private static Market getMarket() {
+        return Market.builder()
+                .id(1L)
+                .idNum(04003)
+                .marketName("강릉중앙시장")
+                .type(1)
+                .roadAddress("강원특별자치도 강릉시 금성로21")
+                .streetAddress("강원특별자치도 강릉시 성남동 50")
+                .location(geometryFactory.createPoint(new Coordinate(37.75402359, 128.8986233)))
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestServiceImplTest.java
+++ b/src/test/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestServiceImplTest.java
@@ -1,9 +1,12 @@
 package com.example.demo.marketpurchaserequest.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.example.demo.exception.MarkethingException;
+import com.example.demo.exception.type.ErrorCode;
 import com.example.demo.market.entity.Market;
 import com.example.demo.market.repository.MarketRepository;
 import com.example.demo.marketpurchaserequest.dto.MarketPurchaseRequestDto;
@@ -62,6 +65,20 @@ public class MarketPurchaseRequestServiceImplTest {
         MarketPurchaseRequest findMarketPurchaseRequest = marketPurchaseRequestRepository.findById(newMarketPurchaseRequest.getId()).orElse(null);
 
         assertEquals(marketPurchaseRequest.getId(),findMarketPurchaseRequest.getId());
+
+    }
+
+    @Test
+    void createFailedByUserNotFound(){
+        // given
+        given(siteUserRepository.findById(any())).willReturn(Optional.empty());
+
+        // when
+        MarkethingException exception = assertThrows(MarkethingException.class,
+                () -> marketPurchaseRequestServiceImpl.createMarketPurchaseRequest(getMarketPurchaseRequestDto(getSiteUser(), getMarket())));
+
+        // then
+        assertEquals(exception.getErrorCode(), ErrorCode.USER_NOT_FOUND);
 
     }
 


### PR DESCRIPTION
## 코드 변경사항

#### AS-IS
- schema.sql에서 존재하지 않는 테이블(chat_message)을 수정하는 오류가 있었습니다.
#### TO-BE
- schema.sql의 오류를 수정합니다.
- 장보기 의뢰글 등록 기능을 추가합니다.

## 테스트 여부
- [x] 테스트 코드
- [x] API 테스트


