### PR TITLE
댓글 달기 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/community/controller/api/CommentApiController.java
+++ b/src/main/java/com/example/demo/community/controller/api/CommentApiController.java
@@ -1,0 +1,26 @@
+package com.example.demo.community.controller.api;
+
+import com.example.demo.community.dto.comment.CommentRequestDto;
+import com.example.demo.community.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/communities/{communityId}")
+public class CommentApiController {
+    private final CommentService commentServie;
+    // 회원 가입 기능 구현 완료 후 user 정보 가져오기 위해 Principal 객체 request에 추가
+    @PostMapping("/comments")
+    public void postComment(@RequestBody CommentRequestDto commentRequestDto
+            , @PathVariable Long communityId) {
+        String email = "mockEmail@gmail.com";
+        commentServie.create(email, communityId, commentRequestDto);
+    }
+
+}

--- a/src/main/java/com/example/demo/community/controller/api/CommentApiController.java
+++ b/src/main/java/com/example/demo/community/controller/api/CommentApiController.java
@@ -7,20 +7,19 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/communities/{communityId}")
 public class CommentApiController {
-    private final CommentService commentServie;
+    private final CommentService commentService;
     // 회원 가입 기능 구현 완료 후 user 정보 가져오기 위해 Principal 객체 request에 추가
     @PostMapping("/comments")
     public void postComment(@RequestBody CommentRequestDto commentRequestDto
             , @PathVariable Long communityId) {
         String email = "mockEmail@gmail.com";
-        commentServie.create(email, communityId, commentRequestDto);
+        commentService.create(email, communityId, commentRequestDto);
     }
 
 }

--- a/src/main/java/com/example/demo/community/dto/comment/CommentRequestDto.java
+++ b/src/main/java/com/example/demo/community/dto/comment/CommentRequestDto.java
@@ -1,0 +1,25 @@
+package com.example.demo.community.dto.comment;
+
+import com.example.demo.community.entity.Comment;
+import com.example.demo.community.entity.Community;
+import com.example.demo.siteuser.entity.SiteUser;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentRequestDto {
+    private String content;
+
+    public Comment toEntity(SiteUser siteUser, Community community) {
+        return Comment.builder()
+                .community(community)
+                .siteUser(siteUser)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/community/repository/CommentRepository.java
+++ b/src/main/java/com/example/demo/community/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.community.repository;
+
+import com.example.demo.community.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/example/demo/community/service/CommentService.java
+++ b/src/main/java/com/example/demo/community/service/CommentService.java
@@ -1,0 +1,9 @@
+package com.example.demo.community.service;
+
+import com.example.demo.community.dto.comment.CommentRequestDto;
+import com.example.demo.community.entity.Comment;
+
+public interface CommentService {
+
+    Comment create(String email, Long communityId, CommentRequestDto commentRequestDto);
+}

--- a/src/main/java/com/example/demo/community/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/example/demo/community/service/impl/CommentServiceImpl.java
@@ -1,0 +1,33 @@
+package com.example.demo.community.service.impl;
+
+import com.example.demo.community.dto.comment.CommentRequestDto;
+import com.example.demo.community.entity.Comment;
+import com.example.demo.community.repository.CommentRepository;
+import com.example.demo.community.repository.CommunityRepository;
+import com.example.demo.community.service.CommentService;
+import com.example.demo.exception.MarkethingException;
+import com.example.demo.exception.type.ErrorCode;
+import com.example.demo.siteuser.repository.SiteUserRepository;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    private final SiteUserRepository siteUserRepository;
+    private final CommunityRepository communityRepository;
+    private final CommentRepository commentRepository;
+
+    @Override
+    @Transactional
+    public Comment create(String email, Long communityId, CommentRequestDto commentRequestDto) {
+        var siteUser = siteUserRepository.findByEmail(email)
+                .orElseThrow(() -> new MarkethingException(ErrorCode.USER_NOT_FOUND));
+        var community = communityRepository.findById(communityId)
+                .orElseThrow(() -> new MarkethingException(ErrorCode.COMMUNITY_NOT_FOUND));
+
+        return commentRepository.save(commentRequestDto.toEntity(siteUser, community));
+    }
+}

--- a/src/main/java/com/example/demo/community/service/impl/CommunityServiceImpl.java
+++ b/src/main/java/com/example/demo/community/service/impl/CommunityServiceImpl.java
@@ -53,6 +53,7 @@ public class CommunityServiceImpl implements CommunityService {
     }
 
     @Override
+    @Transactional
     public void delete(String email, Long communityId) {
         var siteUser = siteUserRepository.findByEmail(email)
                 .orElseThrow(() -> new MarkethingException(EMAIL_NOT_FOUND));

--- a/src/main/java/com/example/demo/community/service/impl/CommunityServiceImpl.java
+++ b/src/main/java/com/example/demo/community/service/impl/CommunityServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.demo.community.service.impl;
 import static com.example.demo.exception.type.ErrorCode.COMMUNITY_NOT_FOUND;
 import static com.example.demo.exception.type.ErrorCode.EMAIL_NOT_FOUND;
 import static com.example.demo.exception.type.ErrorCode.UNAUTHORIZED_USER;
+import static com.example.demo.exception.type.ErrorCode.USER_NOT_FOUND;
 
 import com.example.demo.common.filter.dto.CommunityFilterDto;
 import com.example.demo.community.dto.community.CommunityDetailDto;
@@ -32,7 +33,7 @@ public class CommunityServiceImpl implements CommunityService {
     @Transactional
     public Community create(String email, CommunityRequestDto communityRequestDto) {
         var siteUser = siteUserRepository.findByEmail(email)
-                .orElseThrow(() -> new MarkethingException(EMAIL_NOT_FOUND));
+                .orElseThrow(() -> new MarkethingException(USER_NOT_FOUND));
 
         return communityRepository.save(communityRequestDto.toEntity(siteUser));
     }
@@ -41,7 +42,7 @@ public class CommunityServiceImpl implements CommunityService {
     @Transactional
     public Community edit(String email, CommunityRequestDto communityRequestDto, Long communityId) {
         var siteUser = siteUserRepository.findByEmail(email)
-                .orElseThrow(() -> new MarkethingException(EMAIL_NOT_FOUND));
+                .orElseThrow(() -> new MarkethingException(USER_NOT_FOUND));
 
         var community = communityRepository.findById(communityId)
                 .orElseThrow(() -> new MarkethingException(COMMUNITY_NOT_FOUND));
@@ -56,7 +57,7 @@ public class CommunityServiceImpl implements CommunityService {
     @Transactional
     public void delete(String email, Long communityId) {
         var siteUser = siteUserRepository.findByEmail(email)
-                .orElseThrow(() -> new MarkethingException(EMAIL_NOT_FOUND));
+                .orElseThrow(() -> new MarkethingException(USER_NOT_FOUND));
 
         var community = communityRepository.findById(communityId)
                 .orElseThrow(() -> new MarkethingException(COMMUNITY_NOT_FOUND));

--- a/src/test/java/com/example/demo/community/controller/CommentApiControllerTest.java
+++ b/src/test/java/com/example/demo/community/controller/CommentApiControllerTest.java
@@ -1,0 +1,126 @@
+package com.example.demo.community.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.demo.community.controller.api.CommentApiController;
+import com.example.demo.community.dto.comment.CommentRequestDto;
+import com.example.demo.community.entity.Comment;
+import com.example.demo.community.entity.Community;
+import com.example.demo.community.service.CommentService;
+import com.example.demo.community.type.AreaType;
+import com.example.demo.config.SecurityConfig;
+import com.example.demo.siteuser.entity.SiteUser;
+import com.example.demo.type.AuthType;
+import com.example.demo.type.PostStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+@WebMvcTest(CommentApiController.class)
+@Import(SecurityConfig.class)
+public class CommentApiControllerTest {
+
+    @MockBean
+    private MappingMongoConverter mappingMongoConverter;
+
+    @MockBean
+    private CommentService commentService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void createCommentTest() throws Exception {
+        // given
+        CommentRequestDto commentRequestDto = getCommentRequestDto();
+        Community community = getCommunity();
+        SiteUser siteUser = getSiteUser();
+        Comment comment = getComment(community, siteUser, commentRequestDto);
+
+        String content = objectMapper.writeValueAsString(commentRequestDto);
+
+        given(commentService.create(eq("mockEmail@gmail.com")
+                , eq(community.getId()) ,eq(commentRequestDto)))
+                .willReturn(comment);
+
+        // when & then
+        mockMvc.perform(post("/api/communities/1/comments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    private static Comment getComment(Community community, SiteUser siteUser,
+            CommentRequestDto commentRequestDto) {
+        return Comment.builder()
+                .id(1L)
+                .community(community)
+                .siteUser(siteUser)
+                .content(commentRequestDto.getContent())
+                .postStatus(PostStatus.POST)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private static CommentRequestDto getCommentRequestDto() {
+        return CommentRequestDto
+                .builder()
+                .content("content")
+                .build();
+    }
+
+    private static Community getCommunity() {
+        return Community.builder()
+                .siteUser(getSiteUser())
+                .id(1L)
+                .area(AreaType.SEOUL)
+                .title("title")
+                .content("content")
+                .postImg("postImg")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private static SiteUser getSiteUser() {
+        GeometryFactory geometryFactory = new GeometryFactory();
+        double longitude = 126.97796919; // 경도
+        double latitude = 37.56667062;   // 위도
+        Point myLocation = geometryFactory.createPoint(new Coordinate(longitude, latitude));
+
+        return SiteUser.builder()
+                .id(1L)
+                .email("mockEmail@gmail.com")
+                .password("password")
+                .name("name")
+                .nickname("nickname")
+                .phoneNumber("010-1234-5678")
+                .address("address")
+                .myLocation(myLocation)
+                .mannerScore(0)
+                .profileImg("profileImg")
+                .status(true)
+                .authType(AuthType.GENERAL)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/com/example/demo/community/controller/CommunityApiControllerTest.java
+++ b/src/test/java/com/example/demo/community/controller/CommunityApiControllerTest.java
@@ -49,6 +49,7 @@ public class CommunityApiControllerTest {
 
     @MockBean
     private MappingMongoConverter mappingMongoConverter;
+
     @MockBean
     private CommunityService communityService;
 

--- a/src/test/java/com/example/demo/community/service/CommentServiceImplTest.java
+++ b/src/test/java/com/example/demo/community/service/CommentServiceImplTest.java
@@ -1,0 +1,168 @@
+package com.example.demo.community.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.demo.common.filter.dto.CommunityFilterDto;
+import com.example.demo.community.dto.comment.CommentRequestDto;
+import com.example.demo.community.dto.community.CommunityRequestDto;
+import com.example.demo.community.entity.Comment;
+import com.example.demo.community.entity.Community;
+import com.example.demo.community.repository.CommentRepository;
+import com.example.demo.community.repository.CommunityRepository;
+import com.example.demo.community.service.impl.CommentServiceImpl;
+import com.example.demo.community.service.impl.CommunityServiceImpl;
+import com.example.demo.community.type.AreaType;
+import com.example.demo.exception.MarkethingException;
+import com.example.demo.exception.type.ErrorCode;
+import com.example.demo.siteuser.entity.SiteUser;
+import com.example.demo.siteuser.repository.SiteUserRepository;
+import com.example.demo.type.AuthType;
+import com.example.demo.type.PostStatus;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentServiceImplTest {
+
+    @Mock
+    private CommunityRepository communityRepository;
+
+    @Mock
+    private SiteUserRepository siteUserRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @InjectMocks
+    private CommentServiceImpl commentService;
+
+    @Test
+    void createSuccess() {
+        // given
+        SiteUser siteUser = getSiteUser();
+        Community community = getCommunity();
+        CommentRequestDto commentRequestDto = getCommentRequestDto();
+        Comment comment = getComment(community, siteUser, commentRequestDto);
+
+        given(siteUserRepository.findByEmail(siteUser.getEmail()))
+                .willReturn(Optional.of(siteUser));
+        given(communityRepository.findById(community.getId()))
+                .willReturn(Optional.of(community));
+        given(commentRepository.save(any(Comment.class)))
+                .willReturn(comment);
+
+        // when
+        Comment result = commentService.create(siteUser.getEmail(),
+                community.getId(), commentRequestDto);
+
+        // then
+        assertThat(result.getContent()).isEqualTo(commentRequestDto.getContent());
+    }
+
+    @Test
+    void createFailedByUserNotFound() {
+        // given
+        given(siteUserRepository.findByEmail("mockEmail@gmail.com"))
+                .willReturn(Optional.empty());
+
+        // when
+        MarkethingException exception = assertThrows(MarkethingException.class,
+                () -> commentService.create("mockEmail@gmail.com",
+                        1L, getCommentRequestDto()));
+        // then
+        assertEquals(exception.getErrorCode(), ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    void createFailedByCommunityNotFound() {
+        // given
+        SiteUser siteUser = getSiteUser();
+
+        given(siteUserRepository.findByEmail(siteUser.getEmail()))
+                .willReturn(Optional.of(siteUser));
+        given(communityRepository.findById(eq(1L)))
+                .willReturn(Optional.empty());
+
+        // when
+        MarkethingException exception = assertThrows(MarkethingException.class,
+                () -> commentService.create("mockEmail@gmail.com",
+                        1L, getCommentRequestDto()));
+        // then
+        assertEquals(exception.getErrorCode(), ErrorCode.COMMUNITY_NOT_FOUND);
+    }
+
+    private static CommentRequestDto getCommentRequestDto() {
+        return CommentRequestDto
+                .builder()
+                .content("content")
+                .build();
+    }
+
+    private static Comment getComment(Community community, SiteUser siteUser,
+            CommentRequestDto commentRequestDto) {
+        return Comment.builder()
+                .id(1L)
+                .community(community)
+                .siteUser(siteUser)
+                .content(commentRequestDto.getContent())
+                .postStatus(PostStatus.POST)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private static Community getCommunity() {
+        return Community.builder()
+                .siteUser(getSiteUser())
+                .id(1L)
+                .area(AreaType.SEOUL)
+                .title("title")
+                .content("content")
+                .postImg("postImg")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private static SiteUser getSiteUser() {
+        GeometryFactory geometryFactory = new GeometryFactory();
+        double longitude = 126.97796919; // 경도
+        double latitude = 37.56667062;   // 위도
+        Point myLocation = geometryFactory.createPoint(new Coordinate(longitude, latitude));
+
+        return SiteUser.builder()
+                .id(1L)
+                .email("mockEmail@gmail.com")
+                .password("password")
+                .name("name")
+                .nickname("nickname")
+                .phoneNumber("010-1234-5678")
+                .address("address")
+                .myLocation(myLocation)
+                .mannerScore(0)
+                .profileImg("profileImg")
+                .status(true)
+                .authType(AuthType.GENERAL)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/com/example/demo/community/service/CommunityServiceImplTest.java
+++ b/src/test/java/com/example/demo/community/service/CommunityServiceImplTest.java
@@ -69,12 +69,16 @@ public class CommunityServiceImplTest {
     }
 
     @Test
-    void createFailedByEmailNotFound() {
+    void createFailedByUserNotFound() {
+        // given
+        given(siteUserRepository.findByEmail("mockEmail@gmail.com"))
+                .willReturn(Optional.empty());
+
         // when
         MarkethingException exception = assertThrows(MarkethingException.class,
                 () -> communityService.create("mockEmail@gmail.com", getCommunityRequestDto()));
         // then
-        assertEquals(exception.getErrorCode(), ErrorCode.EMAIL_NOT_FOUND);
+        assertEquals(exception.getErrorCode(), ErrorCode.USER_NOT_FOUND);
     }
 
     @Test
@@ -101,7 +105,7 @@ public class CommunityServiceImplTest {
     }
 
     @Test
-    void editFailedByEmailNotFound() {
+    void editFailedByUserNotFound() {
         // given
         given(siteUserRepository.findByEmail("mockEmail@gmail.com"))
                 .willReturn(Optional.empty());
@@ -111,7 +115,7 @@ public class CommunityServiceImplTest {
                 () -> communityService.edit("mockEmail@gmail.com", getCommunityRequestDto(), 1L));
 
         // then
-        assertEquals(exception.getErrorCode(), ErrorCode.EMAIL_NOT_FOUND);
+        assertEquals(exception.getErrorCode(), ErrorCode.USER_NOT_FOUND);
     }
 
     @Test
@@ -155,7 +159,7 @@ public class CommunityServiceImplTest {
     }
 
     @Test
-    void deleteFailedByEmailNotFound() {
+    void deleteFailedByUserNotFound() {
         // given
         given(siteUserRepository.findByEmail("mockEmail@gmail.com"))
                 .willReturn(Optional.empty());
@@ -165,7 +169,7 @@ public class CommunityServiceImplTest {
                 () -> communityService.delete("mockEmail@gmail.com", 1L));
 
         // then
-        assertEquals(exception.getErrorCode(), ErrorCode.EMAIL_NOT_FOUND);
+        assertEquals(exception.getErrorCode(), ErrorCode.USER_NOT_FOUND);
     }
 
     @Test


### PR DESCRIPTION
## 코드 변경사항

#### AS-IS
- 기존 CommuityServiceTest 클래스에서 이메일로 유저를 찾아오는 데 실패한 경우에 대한 테스트 코드 네이밍을 EmailNotFound로 지정했습니다. 

#### TO-BE
- 댓글 달기 기능 추가합니다.
- 기존에 EmailNotFound로 네이밍한 테스트코드 이름을 UserNotFound로 변경합니다. 

## 테스트 여부
- [x] 테스트 코드
- [x] API 테스트


