### PR TITLE
내 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/siteuser/controller/api/SiteUserApiController.java
+++ b/src/main/java/com/example/demo/siteuser/controller/api/SiteUserApiController.java
@@ -1,14 +1,12 @@
 package com.example.demo.siteuser.controller.api;
 
 import com.example.demo.siteuser.dto.SiteUserResponseDto;
-import com.example.demo.siteuser.entity.SiteUser;
 import com.example.demo.siteuser.service.SiteUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/src/main/java/com/example/demo/siteuser/controller/api/SiteUserApiController.java
+++ b/src/main/java/com/example/demo/siteuser/controller/api/SiteUserApiController.java
@@ -1,8 +1,12 @@
 package com.example.demo.siteuser.controller.api;
 
+import com.example.demo.siteuser.dto.SiteUserResponseDto;
+import com.example.demo.siteuser.entity.SiteUser;
 import com.example.demo.siteuser.service.SiteUserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,4 +24,13 @@ public class SiteUserApiController {
         String email = "mockEmail@gmail.com";
         siteUserService.deleteSiteUser(email);
     }
+
+    @GetMapping("/information")
+    public ResponseEntity<SiteUserResponseDto> getMyInformation() {
+        // TODO: 로그인 된 USER 정보 입력 받아서 자신의 정보만 조회 가능으로 수정 필요!
+        String email = "mockEmail@gmail.com";
+        SiteUserResponseDto response = siteUserService.getMyInformation(email);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/example/demo/siteuser/dto/SiteUserResponseDto.java
+++ b/src/main/java/com/example/demo/siteuser/dto/SiteUserResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.demo.siteuser.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SiteUserResponseDto {
+
+    private String email;
+    private String name;
+    private String phoneNumber;
+    private String address;
+    private int manner;
+    private String profileImg;
+
+}

--- a/src/main/java/com/example/demo/siteuser/dto/SiteUserResponseDto.java
+++ b/src/main/java/com/example/demo/siteuser/dto/SiteUserResponseDto.java
@@ -1,19 +1,33 @@
 package com.example.demo.siteuser.dto;
 
-import lombok.AllArgsConstructor;
+import com.example.demo.siteuser.entity.SiteUser;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
 public class SiteUserResponseDto {
 
     private String email;
     private String name;
     private String phoneNumber;
     private String address;
-    private int manner;
+    private int mannerScore;
     private String profileImg;
+
+    @Builder
+    public SiteUserResponseDto(String email, String name, String phoneNumber, String address, int mannerScore, String profileImg) {
+        this.email = email;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.mannerScore = mannerScore;
+        this.profileImg = profileImg;
+    }
+
+    public static SiteUserResponseDto fromEntity(SiteUser siteUser) {
+        return new SiteUserResponseDto(siteUser.getEmail(), siteUser.getName(), siteUser.getPhoneNumber(),
+                siteUser.getAddress(), siteUser.getMannerScore(), siteUser.getProfileImg());
+
+    }
 
 }

--- a/src/main/java/com/example/demo/siteuser/service/SiteUserService.java
+++ b/src/main/java/com/example/demo/siteuser/service/SiteUserService.java
@@ -1,5 +1,9 @@
 package com.example.demo.siteuser.service;
 
+import com.example.demo.siteuser.dto.SiteUserResponseDto;
+import com.example.demo.siteuser.entity.SiteUser;
+
 public interface SiteUserService {
     void deleteSiteUser(String email);
+    SiteUserResponseDto getMyInformation(String email);
 }

--- a/src/main/java/com/example/demo/siteuser/service/SiteUserService.java
+++ b/src/main/java/com/example/demo/siteuser/service/SiteUserService.java
@@ -1,7 +1,6 @@
 package com.example.demo.siteuser.service;
 
 import com.example.demo.siteuser.dto.SiteUserResponseDto;
-import com.example.demo.siteuser.entity.SiteUser;
 
 public interface SiteUserService {
     void deleteSiteUser(String email);

--- a/src/main/java/com/example/demo/siteuser/service/impl/SiteUserServiceImpl.java
+++ b/src/main/java/com/example/demo/siteuser/service/impl/SiteUserServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.demo.siteuser.service.impl;
 
 import com.example.demo.exception.MarkethingException;
 import com.example.demo.exception.type.ErrorCode;
+import com.example.demo.siteuser.dto.SiteUserResponseDto;
 import com.example.demo.siteuser.entity.SiteUser;
 import com.example.demo.siteuser.repository.SiteUserRepository;
 import com.example.demo.siteuser.service.SiteUserService;
@@ -14,10 +15,19 @@ public class SiteUserServiceImpl implements SiteUserService {
 
     private final SiteUserRepository siteUserRepository;
 
+    public SiteUser getSiteUserByEmail(String email) {
+        return siteUserRepository.findByEmail(email).orElseThrow(()->new MarkethingException(ErrorCode.USER_NOT_FOUND));
+    }
     @Override
     public void deleteSiteUser(String email) {
-        SiteUser siteUser = siteUserRepository.findByEmail(email).orElseThrow(()-> new MarkethingException(
-                ErrorCode.USER_NOT_FOUND));
+        SiteUser siteUser = getSiteUserByEmail(email);
         siteUserRepository.delete(siteUser);
+    }
+
+    @Override
+    public SiteUserResponseDto getMyInformation(String email) {
+        SiteUser siteUser = getSiteUserByEmail(email);
+        return new SiteUserResponseDto(siteUser.getEmail(), siteUser.getName(), siteUser.getPhoneNumber(),
+                siteUser.getAddress(), siteUser.getMannerScore(), siteUser.getProfileImg());
     }
 }

--- a/src/main/java/com/example/demo/siteuser/service/impl/SiteUserServiceImpl.java
+++ b/src/main/java/com/example/demo/siteuser/service/impl/SiteUserServiceImpl.java
@@ -27,7 +27,6 @@ public class SiteUserServiceImpl implements SiteUserService {
     @Override
     public SiteUserResponseDto getMyInformation(String email) {
         SiteUser siteUser = getSiteUserByEmail(email);
-        return new SiteUserResponseDto(siteUser.getEmail(), siteUser.getName(), siteUser.getPhoneNumber(),
-                siteUser.getAddress(), siteUser.getMannerScore(), siteUser.getProfileImg());
+        return SiteUserResponseDto.fromEntity(siteUser);
     }
 }

--- a/src/test/java/com/example/demo/marketpurchaserequest/controller/MarketPurchaseRequestApiControllerTest.java
+++ b/src/test/java/com/example/demo/marketpurchaserequest/controller/MarketPurchaseRequestApiControllerTest.java
@@ -3,8 +3,6 @@ package com.example.demo.marketpurchaserequest.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/com/example/demo/marketpurchaserequest/controller/MarketPurchaseRequestApiControllerTest.java
+++ b/src/test/java/com/example/demo/marketpurchaserequest/controller/MarketPurchaseRequestApiControllerTest.java
@@ -3,6 +3,7 @@ package com.example.demo.marketpurchaserequest.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -25,6 +26,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -88,6 +90,7 @@ public class MarketPurchaseRequestApiControllerTest {
 
     @Test
     @DisplayName("시장 의뢰글 등록 테스트")
+    @WithMockUser
     void createMarketPurchaseRequest() throws Exception {
         // given
         MarketPurchaseRequest marketPurchaseRequest = marketPurchaseRequestDto.toEntity(siteUser,market);
@@ -96,7 +99,7 @@ public class MarketPurchaseRequestApiControllerTest {
 
         // when
         final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
-                .post("/api/requests")
+                .post("/api/requests").with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(marketPurchaseRequestDto)));
         // then
@@ -106,15 +109,16 @@ public class MarketPurchaseRequestApiControllerTest {
 
     @Test
     @DisplayName("시장 의뢰글 삭제 테스트")
+    @WithMockUser
     void deleteMarketPurchaseRequest() throws Exception {
         // given
         MarketPurchaseRequest marketPurchaseRequest = marketPurchaseRequestDto.toEntity(siteUser,market);
 
-        given(marketPurchaseRequestService.createMarketPurchaseRequest(any())).willReturn(marketPurchaseRequest);
+        given(marketPurchaseRequestService.createMarketPurchaseRequest(marketPurchaseRequestDto)).willReturn(marketPurchaseRequest);
         doNothing().when(marketPurchaseRequestService).deleteMarketPurchaseRequest(
                 marketPurchaseRequest.getId());
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.delete("/api/requests/1"))
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/requests/1").with(csrf()))
                 .andExpect(status().isOk()).andDo(print());
     }
 }

--- a/src/test/java/com/example/demo/marketpurchaserequest/controller/MarketPurchaseRequestApiControllerTest.java
+++ b/src/test/java/com/example/demo/marketpurchaserequest/controller/MarketPurchaseRequestApiControllerTest.java
@@ -18,6 +18,7 @@ import com.example.demo.type.AuthType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -88,6 +89,7 @@ public class MarketPurchaseRequestApiControllerTest {
 
 
     @Test
+    @DisplayName("시장 의뢰글 등록 테스트")
     void createMarketPurchaseRequest() throws Exception {
         // given
         MarketPurchaseRequest marketPurchaseRequest = marketPurchaseRequestDto.toEntity(siteUser,market);
@@ -105,6 +107,7 @@ public class MarketPurchaseRequestApiControllerTest {
     }
 
     @Test
+    @DisplayName("시장 의뢰글 삭제 테스트")
     void deleteMarketPurchaseRequest() throws Exception {
         // given
         MarketPurchaseRequest marketPurchaseRequest = marketPurchaseRequestDto.toEntity(siteUser,market);
@@ -114,6 +117,6 @@ public class MarketPurchaseRequestApiControllerTest {
                 marketPurchaseRequest.getId());
         // when & then
         mockMvc.perform(MockMvcRequestBuilders.delete("/api/requests/1"))
-                .andExpect(status().isNoContent()).andDo(print());
+                .andExpect(status().isOk()).andDo(print());
     }
 }

--- a/src/test/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestServiceImplTest.java
+++ b/src/test/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestServiceImplTest.java
@@ -22,6 +22,7 @@ import com.example.demo.type.AuthType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.locationtech.jts.geom.Coordinate;
@@ -48,6 +49,7 @@ public class MarketPurchaseRequestServiceImplTest {
     private static final GeometryFactory geometryFactory = new GeometryFactory();
 
     @Test
+    @DisplayName("시장 의뢰글 등록 성공 테스트")
     void createMarketPurchaseRequest() throws Exception {
         //given
         Market market = getMarket();
@@ -72,6 +74,7 @@ public class MarketPurchaseRequestServiceImplTest {
     }
 
     @Test
+    @DisplayName("시장 의뢰글 등록 실패 테스트 - USER NOT FOUND")
     void createFailedByUserNotFound() throws Exception {
         // given
         given(siteUserRepository.findById(any())).willReturn(Optional.empty());
@@ -85,6 +88,7 @@ public class MarketPurchaseRequestServiceImplTest {
     }
 
     @Test
+    @DisplayName("시장 의뢰글 삭제 성공 테스트")
     void deleteMarketPurchaseRequest() throws Exception {
         //given
         Market market = getMarket();
@@ -103,6 +107,7 @@ public class MarketPurchaseRequestServiceImplTest {
     }
 
     @Test
+    @DisplayName("시장 의뢰글 삭제 실패 테스트 - USER NOT FOUND")
     void deleteFailedByRequestNotFound() throws Exception {
         // given
         given(marketPurchaseRequestRepository.findById(any())).willReturn(Optional.empty());

--- a/src/test/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestServiceImplTest.java
+++ b/src/test/java/com/example/demo/marketpurchaserequest/service/MarketPurchaseRequestServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/com/example/demo/siteuser/controller/SiteUserApiControllerTest.java
+++ b/src/test/java/com/example/demo/siteuser/controller/SiteUserApiControllerTest.java
@@ -72,7 +72,7 @@ public class SiteUserApiControllerTest {
     }
 
     @Test
-    @DisplayName("내 정보 보기 테스트")
+    @DisplayName("내 정보 조회 테스트")
     @WithMockUser
     void getMyInformation() throws Exception {
         // given

--- a/src/test/java/com/example/demo/siteuser/controller/SiteUserApiControllerTest.java
+++ b/src/test/java/com/example/demo/siteuser/controller/SiteUserApiControllerTest.java
@@ -1,17 +1,21 @@
 package com.example.demo.siteuser.controller;
 
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.demo.siteuser.controller.api.SiteUserApiController;
+import com.example.demo.siteuser.dto.SiteUserResponseDto;
 import com.example.demo.siteuser.entity.SiteUser;
 import com.example.demo.siteuser.service.SiteUserService;
 import com.example.demo.type.AuthType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -57,6 +61,7 @@ public class SiteUserApiControllerTest {
             .build();
 
     @Test
+    @DisplayName("회원 삭제 테스트")
     @WithMockUser
     void deleteSiteUser() throws Exception {
         // given
@@ -64,6 +69,19 @@ public class SiteUserApiControllerTest {
         // when & then
         mockMvc.perform(MockMvcRequestBuilders.delete("/api/users").with(csrf()))
                 .andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
+    @DisplayName("내 정보 보기 테스트")
+    @WithMockUser
+    void getMyInformation() throws Exception {
+        // given
+        given(siteUserService.getMyInformation("mockEmail@gmail.com")).willReturn(
+                SiteUserResponseDto.fromEntity(siteUser));
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/users/information")).andExpect(status().isOk()).andExpect(jsonPath("$.email").value("mockEmail@gmail.com")).andDo(print());
+
+
     }
 
 }

--- a/src/test/java/com/example/demo/siteuser/controller/SiteUserApiControllerTest.java
+++ b/src/test/java/com/example/demo/siteuser/controller/SiteUserApiControllerTest.java
@@ -3,11 +3,11 @@ package com.example.demo.siteuser.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.demo.config.SecurityConfig;
 import com.example.demo.siteuser.controller.api.SiteUserApiController;
 import com.example.demo.siteuser.dto.SiteUserResponseDto;
 import com.example.demo.siteuser.entity.SiteUser;
@@ -22,12 +22,14 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @WebMvcTest(controllers = SiteUserApiController.class)
+@Import(SecurityConfig.class)
 public class SiteUserApiControllerTest {
 
     @MockBean
@@ -67,7 +69,7 @@ public class SiteUserApiControllerTest {
         // given
         doNothing().when(siteUserService).deleteSiteUser(siteUser.getEmail());
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.delete("/api/users").with(csrf()))
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/users"))
                 .andExpect(status().isOk()).andDo(print());
     }
 

--- a/src/test/java/com/example/demo/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/demo/siteuser/service/SiteUserServiceTest.java
@@ -2,18 +2,21 @@ package com.example.demo.siteuser.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.example.demo.exception.MarkethingException;
 import com.example.demo.exception.type.ErrorCode;
+import com.example.demo.siteuser.dto.SiteUserResponseDto;
 import com.example.demo.siteuser.entity.SiteUser;
 import com.example.demo.siteuser.repository.SiteUserRepository;
 import com.example.demo.siteuser.service.impl.SiteUserServiceImpl;
 import com.example.demo.type.AuthType;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.locationtech.jts.geom.Coordinate;
@@ -34,7 +37,8 @@ public class SiteUserServiceTest {
     private static final GeometryFactory geometryFactory = new GeometryFactory();
 
     @Test
-    void success_delete_site_user() throws Exception {
+    @DisplayName("회원 삭제 성공 테스트")
+    void successDeleteSiteUser() throws Exception {
         // given
         SiteUser siteUser = getSiteUser();
         lenient().when(siteUserRepository.findByEmail(siteUser.getEmail())).thenReturn(
@@ -46,7 +50,8 @@ public class SiteUserServiceTest {
     }
 
     @Test
-    void fail_delete_site_user() throws Exception {
+    @DisplayName("회원 삭제 실패 테스트 - USER NOT FOUND")
+    void failDeleteSiteUser() throws Exception {
         // given
         SiteUser siteUser = getSiteUser();
         lenient().when(siteUserRepository.findByEmail(siteUser.getEmail())).thenReturn(
@@ -54,6 +59,31 @@ public class SiteUserServiceTest {
         // when
         MarkethingException exception = assertThrows(MarkethingException.class,
                 () -> siteUserServiceImpl.deleteSiteUser(siteUser.getEmail()));
+        // then
+        assertEquals(exception.getErrorCode(), ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("내 정보 보여주기 성공 테스트")
+    void successGetMyInformation() throws Exception {
+        // given
+        SiteUser siteUser = getSiteUser();
+        given(siteUserRepository.findByEmail(siteUser.getEmail())).willReturn(Optional.of(siteUser));
+        // when
+        SiteUserResponseDto find = siteUserServiceImpl.getMyInformation(siteUser.getEmail());
+        // then
+        assertEquals(find.getEmail(), siteUser.getEmail());
+        assertEquals(find.getName(), siteUser.getName());
+    }
+
+    @Test
+    @DisplayName("내 정보 보여주기 실패 테스트 - USER NOT FOUND")
+    void failGetMyInformation() throws Exception {
+        SiteUser siteUser = getSiteUser();
+        given(siteUserRepository.findByEmail(siteUser.getEmail())).willReturn(Optional.empty());
+        // when
+        MarkethingException exception = assertThrows(MarkethingException.class,
+                () -> siteUserServiceImpl.getMyInformation(siteUser.getEmail()));
         // then
         assertEquals(exception.getErrorCode(), ErrorCode.USER_NOT_FOUND);
     }


### PR DESCRIPTION
## 코드 변경사항

#### AS-IS
- 의뢰글 등록,삭제의 테스트들의 Display Name 이 없었습니다.  
- 의뢰글 삭제 return 값을 변경 후, 의뢰글 삭제 테스트에 반영을 안 했습니다.
#### TO-BE
- 내 정보 조회 기능을 추가합니다.
- 각 테스트들의 이해하기 쉽도록, 의뢰글 등록,삭제의 테스트들의 Display Name 을 추가합니다.
- 의뢰글 삭제의 변경된 return 값을 의뢰글 삭제 테스트에 반영합니다.
## 테스트 여부
- [x] 테스트 코드
- [x] API 테스트


